### PR TITLE
Add minimal reference REST API

### DIFF
--- a/rest-api/ref_impl/README.md
+++ b/rest-api/ref_impl/README.md
@@ -1,0 +1,26 @@
+# xAPI Reference Server
+
+This directory contains a minimal reference implementation of the REST API
+described by `../openapi.yaml`. The server is intentionally lightweight and
+relies only on Python's standard library so it can run in restricted
+environments without installing additional dependencies.
+
+## Running the server
+
+```bash
+python3 server.py
+```
+
+By default the server listens on port 8000. It maintains all data in memory so
+any stored items will be lost when the process stops.
+
+## Implemented endpoints
+
+* `GET /` – API root with hypermedia links
+* `GET /statements` – list stored statements
+* `POST /statements` – store a new statement (UUID generated if missing)
+* `GET /statements/{id}` – retrieve a single statement
+* Similar endpoints exist for `activities`, `agents`, and `verbs`.
+
+This implementation only covers a tiny subset of the full specification but
+serves as a starting point for experimentation and testing.

--- a/rest-api/ref_impl/__init__.py
+++ b/rest-api/ref_impl/__init__.py
@@ -1,0 +1,1 @@
+"""Reference implementation of xAPI REST API."""

--- a/rest-api/ref_impl/server.py
+++ b/rest-api/ref_impl/server.py
@@ -1,0 +1,120 @@
+import json
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse
+
+class SimpleXAPIServer(BaseHTTPRequestHandler):
+    statements = []
+    activities = []
+    agents = []
+    verbs = []
+
+    def _send_json(self, status, body, headers=None):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        if headers:
+            for k, v in headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode('utf-8'))
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path == '/':
+            body = {
+                "_links": {
+                    "self": {"href": "/"},
+                    "statements": {"href": "/statements"},
+                    "activities": {"href": "/activities"},
+                    "agents": {"href": "/agents"},
+                    "verbs": {"href": "/verbs"}
+                },
+                "version": "1.0.0",
+                "documentation": "/docs"
+            }
+            self._send_json(200, body)
+        elif path == '/statements':
+            self._send_json(200, SimpleXAPIServer.statements)
+        elif path.startswith('/statements/'):
+            sid = path.split('/')[-1]
+            stmt = next((s for s in SimpleXAPIServer.statements if s.get('id') == sid), None)
+            if stmt:
+                self._send_json(200, stmt)
+            else:
+                self._send_json(404, {"error": "Statement not found"})
+        elif path == '/activities':
+            self._send_json(200, SimpleXAPIServer.activities)
+        elif path.startswith('/activities/'):
+            aid = path.split('/')[-1]
+            act = next((a for a in SimpleXAPIServer.activities if a.get('id') == aid), None)
+            if act:
+                self._send_json(200, act)
+            else:
+                self._send_json(404, {"error": "Activity not found"})
+        elif path == '/agents':
+            self._send_json(200, SimpleXAPIServer.agents)
+        elif path.startswith('/agents/'):
+            agid = path.split('/')[-1]
+            ag = next((a for a in SimpleXAPIServer.agents if a.get('id') == agid), None)
+            if ag:
+                self._send_json(200, ag)
+            else:
+                self._send_json(404, {"error": "Agent not found"})
+        elif path == '/verbs':
+            self._send_json(200, SimpleXAPIServer.verbs)
+        elif path.startswith('/verbs/'):
+            vid = path.split('/')[-1]
+            vb = next((v for v in SimpleXAPIServer.verbs if v.get('id') == vid), None)
+            if vb:
+                self._send_json(200, vb)
+            else:
+                self._send_json(404, {"error": "Verb not found"})
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        content_length = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(content_length)
+        try:
+            body = json.loads(data.decode('utf-8')) if data else {}
+        except json.JSONDecodeError:
+            self._send_json(400, {"error": "Invalid JSON"})
+            return
+
+        if path == '/statements':
+            if 'id' not in body:
+                body['id'] = str(uuid.uuid4())
+            SimpleXAPIServer.statements.append(body)
+            self._send_json(201, {"id": body['id']}, headers={'Location': f"/statements/{body['id']}"})
+        elif path == '/activities':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Activity requires id"})
+                return
+            SimpleXAPIServer.activities.append(body)
+            self._send_json(201, body, headers={'Location': f"/activities/{body['id']}"})
+        elif path == '/agents':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Agent requires id"})
+                return
+            SimpleXAPIServer.agents.append(body)
+            self._send_json(201, body, headers={'Location': f"/agents/{body['id']}"})
+        elif path == '/verbs':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Verb requires id"})
+                return
+            SimpleXAPIServer.verbs.append(body)
+            self._send_json(201, body, headers={'Location': f"/verbs/{body['id']}"})
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+def run(server_class=HTTPServer, handler_class=SimpleXAPIServer, port=8000):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f"Starting xAPI reference server on port {port}...")
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/rest_api/ref_impl/README.md
+++ b/rest_api/ref_impl/README.md
@@ -1,0 +1,26 @@
+# xAPI Reference Server
+
+This directory contains a minimal reference implementation of the REST API
+described by `../openapi.yaml`. The server is intentionally lightweight and
+relies only on Python's standard library so it can run in restricted
+environments without installing additional dependencies.
+
+## Running the server
+
+```bash
+python3 server.py
+```
+
+By default the server listens on port 8000. It maintains all data in memory so
+any stored items will be lost when the process stops.
+
+## Implemented endpoints
+
+* `GET /` – API root with hypermedia links
+* `GET /statements` – list stored statements
+* `POST /statements` – store a new statement (UUID generated if missing)
+* `GET /statements/{id}` – retrieve a single statement
+* Similar endpoints exist for `activities`, `agents`, and `verbs`.
+
+This implementation only covers a tiny subset of the full specification but
+serves as a starting point for experimentation and testing.

--- a/rest_api/ref_impl/__init__.py
+++ b/rest_api/ref_impl/__init__.py
@@ -1,0 +1,1 @@
+"""Reference implementation of xAPI REST API."""

--- a/rest_api/ref_impl/server.py
+++ b/rest_api/ref_impl/server.py
@@ -1,0 +1,120 @@
+import json
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse
+
+class SimpleXAPIServer(BaseHTTPRequestHandler):
+    statements = []
+    activities = []
+    agents = []
+    verbs = []
+
+    def _send_json(self, status, body, headers=None):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        if headers:
+            for k, v in headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode('utf-8'))
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path == '/':
+            body = {
+                "_links": {
+                    "self": {"href": "/"},
+                    "statements": {"href": "/statements"},
+                    "activities": {"href": "/activities"},
+                    "agents": {"href": "/agents"},
+                    "verbs": {"href": "/verbs"}
+                },
+                "version": "1.0.0",
+                "documentation": "/docs"
+            }
+            self._send_json(200, body)
+        elif path == '/statements':
+            self._send_json(200, SimpleXAPIServer.statements)
+        elif path.startswith('/statements/'):
+            sid = path.split('/')[-1]
+            stmt = next((s for s in SimpleXAPIServer.statements if s.get('id') == sid), None)
+            if stmt:
+                self._send_json(200, stmt)
+            else:
+                self._send_json(404, {"error": "Statement not found"})
+        elif path == '/activities':
+            self._send_json(200, SimpleXAPIServer.activities)
+        elif path.startswith('/activities/'):
+            aid = path.split('/')[-1]
+            act = next((a for a in SimpleXAPIServer.activities if a.get('id') == aid), None)
+            if act:
+                self._send_json(200, act)
+            else:
+                self._send_json(404, {"error": "Activity not found"})
+        elif path == '/agents':
+            self._send_json(200, SimpleXAPIServer.agents)
+        elif path.startswith('/agents/'):
+            agid = path.split('/')[-1]
+            ag = next((a for a in SimpleXAPIServer.agents if a.get('id') == agid), None)
+            if ag:
+                self._send_json(200, ag)
+            else:
+                self._send_json(404, {"error": "Agent not found"})
+        elif path == '/verbs':
+            self._send_json(200, SimpleXAPIServer.verbs)
+        elif path.startswith('/verbs/'):
+            vid = path.split('/')[-1]
+            vb = next((v for v in SimpleXAPIServer.verbs if v.get('id') == vid), None)
+            if vb:
+                self._send_json(200, vb)
+            else:
+                self._send_json(404, {"error": "Verb not found"})
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        content_length = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(content_length)
+        try:
+            body = json.loads(data.decode('utf-8')) if data else {}
+        except json.JSONDecodeError:
+            self._send_json(400, {"error": "Invalid JSON"})
+            return
+
+        if path == '/statements':
+            if 'id' not in body:
+                body['id'] = str(uuid.uuid4())
+            SimpleXAPIServer.statements.append(body)
+            self._send_json(201, {"id": body['id']}, headers={'Location': f"/statements/{body['id']}"})
+        elif path == '/activities':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Activity requires id"})
+                return
+            SimpleXAPIServer.activities.append(body)
+            self._send_json(201, body, headers={'Location': f"/activities/{body['id']}"})
+        elif path == '/agents':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Agent requires id"})
+                return
+            SimpleXAPIServer.agents.append(body)
+            self._send_json(201, body, headers={'Location': f"/agents/{body['id']}"})
+        elif path == '/verbs':
+            if 'id' not in body:
+                self._send_json(400, {"error": "Verb requires id"})
+                return
+            SimpleXAPIServer.verbs.append(body)
+            self._send_json(201, body, headers={'Location': f"/verbs/{body['id']}"})
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+def run(server_class=HTTPServer, handler_class=SimpleXAPIServer, port=8000):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f"Starting xAPI reference server on port {port}...")
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,39 @@
+import json
+import threading
+import time
+import unittest
+from urllib.request import urlopen, Request
+from rest_api.ref_impl import server
+
+PORT = 8099
+
+class ServerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.thread = threading.Thread(target=server.run, kwargs={'port': PORT}, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+
+    def test_root_endpoint(self):
+        with urlopen(f'http://localhost:{PORT}/') as resp:
+            data = json.load(resp)
+        self.assertIn('statements', data['_links'])
+
+    def test_post_and_get_statement(self):
+        stmt = {'actor': {'name': 'Alice'}, 'verb': 'did', 'object': 'test'}
+        req = Request(
+            f'http://localhost:{PORT}/statements',
+            data=json.dumps(stmt).encode('utf-8'),
+            method='POST',
+            headers={'Content-Type': 'application/json'}
+        )
+        with urlopen(req) as resp:
+            self.assertEqual(resp.status, 201)
+            created = json.load(resp)
+        sid = created['id']
+        with urlopen(f'http://localhost:{PORT}/statements/{sid}') as resp:
+            returned = json.load(resp)
+        self.assertEqual(returned['id'], sid)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a simple reference server using the Python standard library
- add instructions and example endpoints
- provide tests exercising basic server functionality

## Testing
- `python3 -m unittest tests/test_server.py -v`