### PR TITLE
Add sample data and validation helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+node_modules/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository provides a comprehensive specification for an xAPI (Experience A
 │   ├── xapi.ttl             # Core xAPI ontology in Turtle format
 │   ├── xapi.owl             # OWL representation of xAPI ontology
 │   ├── xapi-shapes.ttl      # SHACL shapes for xAPI data validation
-│   └── extensions/          # Domain-specific xAPI extensions
+│   └── extensions/          # Domain-specific xAPI extensions (see `ontology/extensions/language-learning.ttl`)
 │
 ├── semantic-layer/          # Semantic Knowledge Graph Layer
 │   ├── vkg/                 # Virtual Knowledge Graph specifications
@@ -67,6 +67,24 @@ This project adheres to the following standards and specifications:
 ## Getting Started
 
 Explore the repository structure above and check the documentation in the `/docs` directory for detailed information on each component.
+
+### Running the reference API server
+
+```
+python3 rest_api/ref_impl/server.py
+```
+
+The server listens on port `8000` by default and stores all data in memory. It implements a minimal subset of the API defined in `rest-api/openapi.yaml` and is useful for quick experimentation.
+
+### Sample data and validation
+
+Example xAPI statements are provided under `examples/sample-statements.jsonld`. A helper script in `scripts/validate_samples.py` can validate these statements against the SHACL shapes, provided `pyshacl` and `rdflib` are available in your environment.
+
+```
+python3 scripts/validate_samples.py
+```
+
+Another script `scripts/generate_data.py` demonstrates how to generate additional statements.
 
 ## Contributing
 

--- a/examples/sample-statements.jsonld
+++ b/examples/sample-statements.jsonld
@@ -1,0 +1,21 @@
+[
+  {
+    "@context": "../rest-api/jsonld-context/statement-context.jsonld",
+    "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
+    "actor": { "mbox": "mailto:alice@example.org", "name": "Alice" },
+    "verb": { "id": "http://adlnet.gov/expapi/verbs/completed", "display": {"en": "completed"} },
+    "object": { "id": "http://example.org/activity/example-activity" },
+    "timestamp": "2024-01-01T12:00:00Z"
+  },
+  {
+    "@context": "../rest-api/jsonld-context/statement-context.jsonld",
+    "actor": { "mbox": "mailto:bob@example.org", "name": "Bob" },
+    "verb": { "id": "http://adlnet.gov/expapi/verbs/attempted", "display": {"en": "attempted"} },
+    "object": { "id": "http://example.org/activity/example-quiz" },
+    "result": {
+      "score": { "scaled": 0.85 },
+      "success": true
+    },
+    "timestamp": "2024-02-01T15:30:00Z"
+  }
+]

--- a/ontology/extensions/language-learning.ttl
+++ b/ontology/extensions/language-learning.ttl
@@ -1,0 +1,15 @@
+@prefix xapi: <http://adlnet.gov/expapi/ontology/> .
+@prefix ll: <http://example.org/xapi/ll#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+# Language Learning extension for xAPI
+
+ll:VocabularyPractice a rdfs:Class ;
+    rdfs:subClassOf xapi:Activity ;
+    rdfs:label "Vocabulary Practice"@en ;
+    rdfs:comment "An activity where a learner practices vocabulary."@en .
+
+ll:pronouncedWord a rdfs:Property ;
+    rdfs:label "pronounced word"@en ;
+    rdfs:domain ll:VocabularyPractice ;
+    rdfs:range rdfs:Literal .

--- a/scripts/generate_data.py
+++ b/scripts/generate_data.py
@@ -1,0 +1,21 @@
+"""Generate example xAPI statements in JSON-LD format."""
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+OUTPUT = Path(__file__).resolve().parent.parent / 'examples' / 'generated-statements.jsonld'
+
+statements = [
+    {
+        "@context": "../rest-api/jsonld-context/statement-context.jsonld",
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "actor": {"mbox": "mailto:test@example.org", "name": "Test User"},
+        "verb": {"id": "http://adlnet.gov/expapi/verbs/experienced", "display": {"en": "experienced"}},
+        "object": {"id": "http://example.org/activity/demo"},
+        "timestamp": datetime.utcnow().isoformat() + 'Z'
+    }
+]
+
+OUTPUT.write_text(json.dumps(statements, indent=2))
+print(f'Wrote example statements to {OUTPUT}')

--- a/scripts/validate_samples.py
+++ b/scripts/validate_samples.py
@@ -1,0 +1,33 @@
+"""Validate example xAPI statements against SHACL shapes."""
+import os
+import sys
+
+try:
+    from pyshacl import validate
+    from rdflib import Graph
+except ImportError:
+    print("pyshacl or rdflib not installed. Please install them to run validation.")
+    sys.exit(0)
+
+BASE = os.path.dirname(os.path.dirname(__file__))
+statements_file = os.path.join(BASE, 'examples', 'sample-statements.jsonld')
+shapes_file = os.path.join(BASE, 'ontology', 'xapi-shapes.ttl')
+
+print(f'Validating {statements_file} against {shapes_file}...')
+
+# Load data and shapes
+data_graph = Graph().parse(statements_file, format='json-ld')
+shapes_graph = Graph().parse(shapes_file, format='turtle')
+
+conforms, report_graph, report_text = validate(
+    data_graph,
+    shacl_graph=shapes_graph,
+    inference='rdfs',
+    serialize_report_graph=True
+)
+
+print(report_text)
+if conforms:
+    print('Validation successful!')
+else:
+    print('Validation failed.')


### PR DESCRIPTION
## Summary
- document how to run the reference API server
- provide sample xAPI statements and helper scripts
- add an example ontology extension for language learning
- ignore build artefacts

## Testing
- `python3 -m unittest tests/test_server.py -v`